### PR TITLE
nnUNetv2 install workaround fixes

### DIFF
--- a/SlicerNNUnet/SlicerNNUNetLib/InstallLogic.py
+++ b/SlicerNNUnet/SlicerNNUNetLib/InstallLogic.py
@@ -219,7 +219,7 @@ class InstallLogic:
         ret = qt.QMessageBox.question(
             None,
             "nnUNet about to be installed",
-            "nnUNet and PyTorch will be installed to 3D Slicer. "
+            "nnUNet will be installed to 3D Slicer. "
             "This install can take a few minutes. "
             "Would you like to proceed?"
         )

--- a/SlicerNNUnet/SlicerNNUNetLib/InstallLogic.py
+++ b/SlicerNNUnet/SlicerNNUNetLib/InstallLogic.py
@@ -81,7 +81,6 @@ class InstallLogic:
 
             self._log(f"Start nnUNet install with requirements : {nnUNetRequirements}")
             self._installPandas()
-            self._downgradePillowToLessThan10_1()
             torchRequirement = self._installNNUnet(nnUNetRequirements)
             self._installPyTorch(torchRequirement)
             self._installACVLUtils()  # Since acvl_utils requires pytorch, we need to install acvl_utils after pytorch.
@@ -280,16 +279,6 @@ class InstallLogic:
                 "This module requires PyTorch extension. "
                 "Install it from the Extensions Manager and restart Slicer to continue."
             )
-
-    def _downgradePillowToLessThan10_1(self) -> None:
-        """
-        Pillow version that is installed in Slicer (10.1.0) is too new,
-        it is incompatible with several nnUNet dependencies.
-        Attempt to uninstall and install an older version before any of the packages import  it.
-        """
-        needToInstallPillow = parse(version("pillow")) >= parse("10.1")
-        if needToInstallPillow:
-            self.pip_install("pillow<10.1")
 
     def _installPandas(self) -> None:
         """

--- a/SlicerNNUnet/SlicerNNUNetLib/InstallLogic.py
+++ b/SlicerNNUnet/SlicerNNUNetLib/InstallLogic.py
@@ -80,7 +80,6 @@ class InstallLogic:
                 self._requestPermissionToInstallOrRaise()
 
             self._log(f"Start nnUNet install with requirements : {nnUNetRequirements}")
-            self._installPandas()
             torchRequirement = self._installNNUnet(nnUNetRequirements)
             self._installPyTorch(torchRequirement)
             self._installACVLUtils()  # Since acvl_utils requires pytorch, we need to install acvl_utils after pytorch.
@@ -279,15 +278,6 @@ class InstallLogic:
                 "This module requires PyTorch extension. "
                 "Install it from the Extensions Manager and restart Slicer to continue."
             )
-
-    def _installPandas(self) -> None:
-        """
-        Installs pandas if necessary.
-        """
-        try:
-            import pandas
-        except ModuleNotFoundError:
-            self.pip_install("pandas")
 
     def pipInstallSelective(self, packageToInstall, installCommand, packagesToSkip):
         """

--- a/SlicerNNUnet/SlicerNNUNetLib/InstallLogic.py
+++ b/SlicerNNUnet/SlicerNNUNetLib/InstallLogic.py
@@ -320,7 +320,8 @@ class InstallLogic:
                     return True
             return False
 
-        with open(cls.packageMetaFilePath(packageToInstall), "r+", encoding="utf-8") as file:
+        # Use Latin-1 encoding to read the file, as it may contain non-ASCII characters and not necessarily in UTF-8 encoding.
+        with open(cls.packageMetaFilePath(packageToInstall), "r+", encoding="latin1") as file:
             filteredLines = "".join([line for line in file if not doSkipLine(line)])
             file.seek(0)
             file.write(filteredLines)


### PR DESCRIPTION
This includes several commits from the [SlicerTotalSegmentator](https://github.com/lassoan/SlicerTotalSegmentator) extension which had workaround fixes associated with installing nnunetv2 and its dependencies.  As originally discussed at https://github.com/Slicer/ExtensionsIndex/pull/2016#issuecomment-2004337762, this extension is to serve as a way to centrally maintain the install of nnUNet in Slicer.

This therefore closes https://github.com/KitwareMedical/SlicerNNUnet/issues/10 where an error was observed during install of nnunetv2.


## Testing with SlicerDentalSegmentator
I have tested this in the context of [SlicerDentalSegmentator](https://github.com/gaudot/SlicerDentalSegmentator) where this closes https://github.com/gaudot/SlicerDentalSegmentator/issues/21. I am now able to run DentalSegmentator using the CBCT Dental Surgery sample data set and get successful results where previously I ran into issues during install of python packages. I used a fresh install of Slicer 5.7.0-2024-12-31 with a cleared out system pip cache so that all downloads would be fresh.
![image](https://github.com/user-attachments/assets/ffc72bd8-cfcf-4962-94c1-5d0538d8c6a5)

<details>
  <summary>DentalSegmentator python console output click here</summary>

```
Python 3.9.10 (main, Dec 31 2024, 23:19:20) [MSC v.1939 64 bit (AMD64)] on win32
>>> 
[Qt] void __cdecl qMRMLSegmentEditorWidget::setSourceVolumeNode(class vtkMRMLNode *)  failed: need to set segment editor and segmentation nodes first
Collecting nnunetv2
  Downloading nnunetv2-2.5.1.tar.gz (196 kB)
     ------------------------------------ 197.0/197.0 kB 919.8 kB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Building wheels for collected packages: nnunetv2
  Building wheel for nnunetv2 (pyproject.toml): started
  Building wheel for nnunetv2 (pyproject.toml): finished with status 'done'
  Created wheel for nnunetv2: filename=nnunetv2-2.5.1-py3-none-any.whl size=264428 sha256=557efde55b579236d8846943f74854f469e1cd8c8a75e6a0268862e8821bab00
  Stored in directory: c:\users\butlej30383\appdata\local\pip\cache\wheels\7b\85\af\51e5381b7cf9cc417ca071b9cd6e35afc59236a0ebb4462249
Successfully built nnunetv2
Installing collected packages: nnunetv2
Successfully installed nnunetv2-2.5.1
Collecting dynamic-network-architectures<0.4,>=0.3.1
  Downloading dynamic_network_architectures-0.3.1.tar.gz (20 kB)
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Building wheels for collected packages: dynamic-network-architectures
  Building wheel for dynamic-network-architectures (setup.py): started
  Building wheel for dynamic-network-architectures (setup.py): finished with status 'done'
  Created wheel for dynamic-network-architectures: filename=dynamic_network_architectures-0.3.1-py3-none-any.whl size=30056 sha256=5fa8fae7292a5f7ae3e656a4866d3a71262c51fd12ab6d0bb3fadbc79fd93286
  Stored in directory: c:\users\butlej30383\appdata\local\pip\cache\wheels\ec\59\c1\e65ad8b5ac7df95651f913251875b4cc8275644e0e28e82c63
Successfully built dynamic-network-architectures
Installing collected packages: dynamic-network-architectures
Successfully installed dynamic-network-architectures-0.3.1
Collecting tqdm
  Downloading tqdm-4.67.1-py3-none-any.whl.metadata (57 kB)
     -------------------------------------- 57.7/57.7 kB 504.6 kB/s eta 0:00:00
Downloading tqdm-4.67.1-py3-none-any.whl (78 kB)
   ---------------------------------------- 78.5/78.5 kB 2.2 MB/s eta 0:00:00
Installing collected packages: tqdm
Successfully installed tqdm-4.67.1
Collecting colorama
  Downloading colorama-0.4.6-py2.py3-none-any.whl.metadata (17 kB)
Downloading colorama-0.4.6-py2.py3-none-any.whl (25 kB)
Installing collected packages: colorama
Successfully installed colorama-0.4.6
Collecting dicom2nifti
  Downloading dicom2nifti-2.5.1-py3-none-any.whl.metadata (1.3 kB)
Downloading dicom2nifti-2.5.1-py3-none-any.whl (43 kB)
   ---------------------------------------- 43.6/43.6 kB 710.8 kB/s eta 0:00:00
Installing collected packages: dicom2nifti
Successfully installed dicom2nifti-2.5.1
Collecting nibabel
  Downloading nibabel-5.3.2-py3-none-any.whl.metadata (9.1 kB)
Downloading nibabel-5.3.2-py3-none-any.whl (3.3 MB)
   ---------------------------------------- 3.3/3.3 MB 5.5 MB/s eta 0:00:00
Installing collected packages: nibabel
Successfully installed nibabel-5.3.2
Collecting importlib-resources>=5.12
  Downloading importlib_resources-6.4.5-py3-none-any.whl.metadata (4.0 kB)
Downloading importlib_resources-6.4.5-py3-none-any.whl (36 kB)
Installing collected packages: importlib-resources
Successfully installed importlib-resources-6.4.5
Collecting zipp>=3.1.0
  Downloading zipp-3.21.0-py3-none-any.whl.metadata (3.7 kB)
Downloading zipp-3.21.0-py3-none-any.whl (9.6 kB)
Installing collected packages: zipp
Successfully installed zipp-3.21.0
Collecting python-gdcm
  Downloading python_gdcm-3.0.24.1-cp39-cp39-win_amd64.whl.metadata (3.8 kB)
Downloading python_gdcm-3.0.24.1-cp39-cp39-win_amd64.whl (28.9 MB)
   ---------------------------------------- 28.9/28.9 MB 7.3 MB/s eta 0:00:00
Installing collected packages: python-gdcm
Successfully installed python-gdcm-3.0.24.1
Collecting batchgenerators>=0.25
  Downloading batchgenerators-0.25.1.tar.gz (76 kB)
     -------------------------------------- 77.0/77.0 kB 855.5 kB/s eta 0:00:00
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Building wheels for collected packages: batchgenerators
  Building wheel for batchgenerators (setup.py): started
  Building wheel for batchgenerators (setup.py): finished with status 'done'
  Created wheel for batchgenerators: filename=batchgenerators-0.25.1-py3-none-any.whl size=93102 sha256=7fa22821f6ad387b26dca74114bb8ee5ec32751344b282bc631f14e1c3fe884f
  Stored in directory: c:\users\butlej30383\appdata\local\pip\cache\wheels\97\8d\b9\3a9435d619b6a4bcd98f8cb8b324da29b6173555bb80860bdd
Successfully built batchgenerators
Installing collected packages: batchgenerators
Successfully installed batchgenerators-0.25.1
Collecting scikit-image
  Downloading scikit_image-0.24.0-cp39-cp39-win_amd64.whl.metadata (14 kB)
Downloading scikit_image-0.24.0-cp39-cp39-win_amd64.whl (12.9 MB)
   ---------------------------------------- 12.9/12.9 MB 5.1 MB/s eta 0:00:00
Installing collected packages: scikit-image
Successfully installed scikit-image-0.24.0
Collecting networkx>=2.8
  Downloading networkx-3.2.1-py3-none-any.whl.metadata (5.2 kB)
Downloading networkx-3.2.1-py3-none-any.whl (1.6 MB)
   ---------------------------------------- 1.6/1.6 MB 5.2 MB/s eta 0:00:00
Installing collected packages: networkx
Successfully installed networkx-3.2.1
Collecting imageio>=2.33
  Downloading imageio-2.36.1-py3-none-any.whl.metadata (5.2 kB)
Downloading imageio-2.36.1-py3-none-any.whl (315 kB)
   ---------------------------------------- 315.4/315.4 kB 2.2 MB/s eta 0:00:00
Installing collected packages: imageio
Successfully installed imageio-2.36.1
Collecting tifffile>=2022.8.12
  Downloading tifffile-2024.8.30-py3-none-any.whl.metadata (31 kB)
Downloading tifffile-2024.8.30-py3-none-any.whl (227 kB)
   ---------------------------------------- 227.3/227.3 kB 2.8 MB/s eta 0:00:00
Installing collected packages: tifffile
Successfully installed tifffile-2024.8.30
Collecting lazy-loader>=0.4
  Downloading lazy_loader-0.4-py3-none-any.whl.metadata (7.6 kB)
Downloading lazy_loader-0.4-py3-none-any.whl (12 kB)
Installing collected packages: lazy-loader
Successfully installed lazy-loader-0.4
Collecting scikit-learn
  Downloading scikit_learn-1.6.0-cp39-cp39-win_amd64.whl.metadata (15 kB)
Downloading scikit_learn-1.6.0-cp39-cp39-win_amd64.whl (11.1 MB)
   ---------------------------------------- 11.1/11.1 MB 7.7 MB/s eta 0:00:00
Installing collected packages: scikit-learn
Successfully installed scikit-learn-1.6.0
Collecting joblib>=1.2.0
  Downloading joblib-1.4.2-py3-none-any.whl.metadata (5.4 kB)
Downloading joblib-1.4.2-py3-none-any.whl (301 kB)
   ---------------------------------------- 301.8/301.8 kB 1.7 MB/s eta 0:00:00
Installing collected packages: joblib
Successfully installed joblib-1.4.2
Collecting threadpoolctl>=3.1.0
  Downloading threadpoolctl-3.5.0-py3-none-any.whl.metadata (13 kB)
Downloading threadpoolctl-3.5.0-py3-none-any.whl (18 kB)
Installing collected packages: threadpoolctl
Successfully installed threadpoolctl-3.5.0
Collecting future
  Downloading future-1.0.0-py3-none-any.whl.metadata (4.0 kB)
Downloading future-1.0.0-py3-none-any.whl (491 kB)
   -------------------------------------- 491.3/491.3 kB 962.2 kB/s eta 0:00:00
Installing collected packages: future
Successfully installed future-1.0.0
Collecting pandas
  Downloading pandas-2.2.3-cp39-cp39-win_amd64.whl.metadata (19 kB)
Downloading pandas-2.2.3-cp39-cp39-win_amd64.whl (11.6 MB)
   ---------------------------------------- 11.6/11.6 MB 6.2 MB/s eta 0:00:00
Installing collected packages: pandas
Successfully installed pandas-2.2.3
Collecting pytz>=2020.1
  Downloading pytz-2024.2-py2.py3-none-any.whl.metadata (22 kB)
Downloading pytz-2024.2-py2.py3-none-any.whl (508 kB)
   ---------------------------------------- 508.0/508.0 kB 3.2 MB/s eta 0:00:00
Installing collected packages: pytz
Successfully installed pytz-2024.2
Collecting tzdata>=2022.7
  Downloading tzdata-2024.2-py2.py3-none-any.whl.metadata (1.4 kB)
Downloading tzdata-2024.2-py2.py3-none-any.whl (346 kB)
   ---------------------------------------- 346.6/346.6 kB 2.2 MB/s eta 0:00:00
Installing collected packages: tzdata
Successfully installed tzdata-2024.2
Collecting unittest2
  Downloading unittest2-1.1.0-py2.py3-none-any.whl.metadata (15 kB)
Downloading unittest2-1.1.0-py2.py3-none-any.whl (96 kB)
   ---------------------------------------- 96.4/96.4 kB 1.4 MB/s eta 0:00:00
Installing collected packages: unittest2
Successfully installed unittest2-1.1.0
Collecting argparse
  Downloading argparse-1.4.0-py2.py3-none-any.whl.metadata (2.8 kB)
Downloading argparse-1.4.0-py2.py3-none-any.whl (23 kB)
Installing collected packages: argparse
Successfully installed argparse-1.4.0
Collecting traceback2
  Downloading traceback2-1.4.0-py2.py3-none-any.whl.metadata (1.5 kB)
Downloading traceback2-1.4.0-py2.py3-none-any.whl (16 kB)
Installing collected packages: traceback2
Successfully installed traceback2-1.4.0
Collecting linecache2
  Downloading linecache2-1.0.0-py2.py3-none-any.whl.metadata (1000 bytes)
Downloading linecache2-1.0.0-py2.py3-none-any.whl (12 kB)
Installing collected packages: linecache2
Successfully installed linecache2-1.0.0
Collecting graphviz
  Downloading graphviz-0.20.3-py3-none-any.whl.metadata (12 kB)
Downloading graphviz-0.20.3-py3-none-any.whl (47 kB)
   ---------------------------------------- 47.1/47.1 kB 784.8 kB/s eta 0:00:00
Installing collected packages: graphviz
Successfully installed graphviz-0.20.3
Collecting matplotlib
  Downloading matplotlib-3.9.4-cp39-cp39-win_amd64.whl.metadata (11 kB)
Downloading matplotlib-3.9.4-cp39-cp39-win_amd64.whl (7.8 MB)
   ---------------------------------------- 7.8/7.8 MB 5.1 MB/s eta 0:00:00
Installing collected packages: matplotlib
Successfully installed matplotlib-3.9.4
Collecting contourpy>=1.0.1
  Downloading contourpy-1.3.0-cp39-cp39-win_amd64.whl.metadata (5.4 kB)
Downloading contourpy-1.3.0-cp39-cp39-win_amd64.whl (211 kB)
   ---------------------------------------- 211.8/211.8 kB 1.3 MB/s eta 0:00:00
Installing collected packages: contourpy
Successfully installed contourpy-1.3.0
Collecting cycler>=0.10
  Downloading cycler-0.12.1-py3-none-any.whl.metadata (3.8 kB)
Downloading cycler-0.12.1-py3-none-any.whl (8.3 kB)
Installing collected packages: cycler
Successfully installed cycler-0.12.1
Collecting fonttools>=4.22.0
  Downloading fonttools-4.55.3-cp39-cp39-win_amd64.whl.metadata (168 kB)
     -------------------------------------- 168.5/168.5 kB 1.3 MB/s eta 0:00:00
Downloading fonttools-4.55.3-cp39-cp39-win_amd64.whl (2.2 MB)
   ---------------------------------------- 2.2/2.2 MB 7.8 MB/s eta 0:00:00
Installing collected packages: fonttools
Successfully installed fonttools-4.55.3
Collecting kiwisolver>=1.3.1
  Downloading kiwisolver-1.4.7-cp39-cp39-win_amd64.whl.metadata (6.4 kB)
Downloading kiwisolver-1.4.7-cp39-cp39-win_amd64.whl (55 kB)
   ---------------------------------------- 55.8/55.8 kB 723.9 kB/s eta 0:00:00
Installing collected packages: kiwisolver
Successfully installed kiwisolver-1.4.7
Collecting seaborn
  Downloading seaborn-0.13.2-py3-none-any.whl.metadata (5.4 kB)
Downloading seaborn-0.13.2-py3-none-any.whl (294 kB)
   ---------------------------------------- 294.9/294.9 kB 2.0 MB/s eta 0:00:00
Installing collected packages: seaborn
Successfully installed seaborn-0.13.2
Collecting imagecodecs
  Downloading imagecodecs-2024.12.30-1-cp39-cp39-win_amd64.whl.metadata (19 kB)
Downloading imagecodecs-2024.12.30-1-cp39-cp39-win_amd64.whl (28.9 MB)
   ---------------------------------------- 28.9/28.9 MB 6.2 MB/s eta 0:00:00
Installing collected packages: imagecodecs
Successfully installed imagecodecs-2024.12.30
Collecting yacs
  Downloading yacs-0.1.8-py3-none-any.whl.metadata (639 bytes)
Downloading yacs-0.1.8-py3-none-any.whl (14 kB)
Installing collected packages: yacs
Successfully installed yacs-0.1.8
Collecting PyYAML
  Downloading PyYAML-6.0.2-cp39-cp39-win_amd64.whl.metadata (2.1 kB)
Downloading PyYAML-6.0.2-cp39-cp39-win_amd64.whl (162 kB)
   ---------------------------------------- 162.3/162.3 kB 1.2 MB/s eta 0:00:00
Installing collected packages: PyYAML
Successfully installed PyYAML-6.0.2
Collecting batchgeneratorsv2>=0.2
  Downloading batchgeneratorsv2-0.2.1.tar.gz (34 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Building wheels for collected packages: batchgeneratorsv2
  Building wheel for batchgeneratorsv2 (pyproject.toml): started
  Building wheel for batchgeneratorsv2 (pyproject.toml): finished with status 'done'
  Created wheel for batchgeneratorsv2: filename=batchgeneratorsv2-0.2.1-py3-none-any.whl size=45216 sha256=c96d79d541dec23011b7579b7316308b08850017ece1a5a1dd0a91958be7f5a2
  Stored in directory: c:\users\butlej30383\appdata\local\pip\cache\wheels\8c\29\14\3fdf4a97638724355746fb142b55db6868f1c0f1698af26ebd
Successfully built batchgeneratorsv2
Installing collected packages: batchgeneratorsv2
Successfully installed batchgeneratorsv2-0.2.1
Collecting fft-conv-pytorch
  Downloading fft_conv_pytorch-1.2.0-py3-none-any.whl.metadata (2.8 kB)
Downloading fft_conv_pytorch-1.2.0-py3-none-any.whl (6.8 kB)
Installing collected packages: fft-conv-pytorch
Successfully installed fft-conv-pytorch-1.2.0
Collecting einops
  Downloading einops-0.8.0-py3-none-any.whl.metadata (12 kB)
Downloading einops-0.8.0-py3-none-any.whl (43 kB)
   ---------------------------------------- 43.2/43.2 kB 1.0 MB/s eta 0:00:00
Installing collected packages: einops
Successfully installed einops-0.8.0
Collecting light-the-torch>=0.5
  Downloading light_the_torch-0.8.0-py3-none-any.whl.metadata (9.3 kB)
Requirement already satisfied: pip<24.4,>=22.3 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from light-the-torch>=0.5) (24.0)
Downloading light_the_torch-0.8.0-py3-none-any.whl (14 kB)
Installing collected packages: light-the-torch
Successfully installed light-the-torch-0.8.0
Collecting torch>=2.1.2
  Downloading https://download.pytorch.org/whl/cu124/torch-2.5.1%2Bcu124-cp39-cp39-win_amd64.whl (2510.7 MB)
     ---------------------------------------- 2.5/2.5 GB 2.0 MB/s eta 0:00:00
Collecting torchvision
  Downloading https://download.pytorch.org/whl/cu124/torchvision-0.20.1%2Bcu124-cp39-cp39-win_amd64.whl (6.1 MB)
     ---------------------------------------- 6.1/6.1 MB 14.0 MB/s eta 0:00:00
Collecting filelock (from torch>=2.1.2)
  Downloading https://download.pytorch.org/whl/filelock-3.13.1-py3-none-any.whl (11 kB)
Requirement already satisfied: typing-extensions>=4.8.0 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from torch>=2.1.2) (4.12.1)
Requirement already satisfied: networkx in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from torch>=2.1.2) (3.2.1)
Collecting jinja2 (from torch>=2.1.2)
  Downloading jinja2-3.1.5-py3-none-any.whl.metadata (2.6 kB)
Collecting fsspec (from torch>=2.1.2)
  Downloading https://download.pytorch.org/whl/fsspec-2024.2.0-py3-none-any.whl (170 kB)
     -------------------------------------- 170.9/170.9 kB 5.2 MB/s eta 0:00:00
Collecting sympy==1.13.1 (from torch>=2.1.2)
  Downloading https://download.pytorch.org/whl/sympy-1.13.1-py3-none-any.whl (6.2 MB)
     ---------------------------------------- 6.2/6.2 MB 18.0 MB/s eta 0:00:00
Collecting mpmath<1.4,>=1.1.0 (from sympy==1.13.1->torch>=2.1.2)
  Downloading https://download.pytorch.org/whl/mpmath-1.3.0-py3-none-any.whl (536 kB)
     ------------------------------------- 536.2/536.2 kB 17.0 MB/s eta 0:00:00
Requirement already satisfied: numpy in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from torchvision) (1.26.4)
Requirement already satisfied: pillow!=8.3.*,>=5.3.0 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from torchvision) (10.3.0)
Collecting MarkupSafe>=2.0 (from jinja2->torch>=2.1.2)
  Downloading MarkupSafe-3.0.2-cp39-cp39-win_amd64.whl.metadata (4.1 kB)
Downloading jinja2-3.1.5-py3-none-any.whl (134 kB)
   ---------------------------------------- 134.6/134.6 kB 1.6 MB/s eta 0:00:00
Downloading MarkupSafe-3.0.2-cp39-cp39-win_amd64.whl (15 kB)
Installing collected packages: mpmath, sympy, MarkupSafe, fsspec, filelock, jinja2, torch, torchvision
Successfully installed MarkupSafe-3.0.2 filelock-3.13.1 fsspec-2024.2.0 jinja2-3.1.5 mpmath-1.3.0 sympy-1.13.1 torch-2.5.1+cu124 torchvision-0.20.1+cu124
Collecting acvl_utils==0.2
  Downloading acvl_utils-0.2.tar.gz (18 kB)
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Requirement already satisfied: numpy in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from acvl_utils==0.2) (1.26.4)
Requirement already satisfied: batchgenerators in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from acvl_utils==0.2) (0.25.1)
Requirement already satisfied: torch in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from acvl_utils==0.2) (2.5.1+cu124)
Requirement already satisfied: SimpleITK in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from acvl_utils==0.2) (2.4.0rc2.dev213)
Requirement already satisfied: scikit-image in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from acvl_utils==0.2) (0.24.0)
Collecting connected-components-3d (from acvl_utils==0.2)
  Downloading connected_components_3d-3.22.0-cp39-cp39-win_amd64.whl.metadata (32 kB)
Requirement already satisfied: pillow>=7.1.2 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from batchgenerators->acvl_utils==0.2) (10.3.0)
Requirement already satisfied: scipy in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from batchgenerators->acvl_utils==0.2) (1.13.1)
Requirement already satisfied: scikit-learn in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from batchgenerators->acvl_utils==0.2) (1.6.0)
Requirement already satisfied: future in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from batchgenerators->acvl_utils==0.2) (1.0.0)
Requirement already satisfied: pandas in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from batchgenerators->acvl_utils==0.2) (2.2.3)
Requirement already satisfied: unittest2 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from batchgenerators->acvl_utils==0.2) (1.1.0)
Requirement already satisfied: threadpoolctl in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from batchgenerators->acvl_utils==0.2) (3.5.0)
Requirement already satisfied: networkx>=2.8 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from scikit-image->acvl_utils==0.2) (3.2.1)
Requirement already satisfied: imageio>=2.33 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from scikit-image->acvl_utils==0.2) (2.36.1)
Requirement already satisfied: tifffile>=2022.8.12 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from scikit-image->acvl_utils==0.2) (2024.8.30)
Requirement already satisfied: packaging>=21 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from scikit-image->acvl_utils==0.2) (24.0)
Requirement already satisfied: lazy-loader>=0.4 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from scikit-image->acvl_utils==0.2) (0.4)
Requirement already satisfied: filelock in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from torch->acvl_utils==0.2) (3.13.1)
Requirement already satisfied: typing-extensions>=4.8.0 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from torch->acvl_utils==0.2) (4.12.1)
Requirement already satisfied: jinja2 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from torch->acvl_utils==0.2) (3.1.5)
Requirement already satisfied: fsspec in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from torch->acvl_utils==0.2) (2024.2.0)
Requirement already satisfied: sympy==1.13.1 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from torch->acvl_utils==0.2) (1.13.1)
Requirement already satisfied: mpmath<1.4,>=1.1.0 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from sympy==1.13.1->torch->acvl_utils==0.2) (1.3.0)
Requirement already satisfied: MarkupSafe>=2.0 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from jinja2->torch->acvl_utils==0.2) (3.0.2)
Requirement already satisfied: python-dateutil>=2.8.2 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from pandas->batchgenerators->acvl_utils==0.2) (2.9.0.post0)
Requirement already satisfied: pytz>=2020.1 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from pandas->batchgenerators->acvl_utils==0.2) (2024.2)
Requirement already satisfied: tzdata>=2022.7 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from pandas->batchgenerators->acvl_utils==0.2) (2024.2)
Requirement already satisfied: joblib>=1.2.0 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from scikit-learn->batchgenerators->acvl_utils==0.2) (1.4.2)
Collecting argparse (from unittest2->batchgenerators->acvl_utils==0.2)
  Using cached argparse-1.4.0-py2.py3-none-any.whl.metadata (2.8 kB)
Requirement already satisfied: six>=1.4 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from unittest2->batchgenerators->acvl_utils==0.2) (1.16.0)
Requirement already satisfied: traceback2 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from unittest2->batchgenerators->acvl_utils==0.2) (1.4.0)
Requirement already satisfied: linecache2 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from traceback2->unittest2->batchgenerators->acvl_utils==0.2) (1.0.0)
Downloading connected_components_3d-3.22.0-cp39-cp39-win_amd64.whl (545 kB)
   -------------------------------------- 545.5/545.5 kB 978.5 kB/s eta 0:00:00
Using cached argparse-1.4.0-py2.py3-none-any.whl (23 kB)
Building wheels for collected packages: acvl_utils
  Building wheel for acvl_utils (setup.py): started
  Building wheel for acvl_utils (setup.py): finished with status 'done'
  Created wheel for acvl_utils: filename=acvl_utils-0.2-py3-none-any.whl size=22450 sha256=4dd58631f62b974d173a462023400c9d5b970cc13535e2723716f15d424e3f5b
  Stored in directory: c:\users\butlej30383\appdata\local\pip\cache\wheels\db\79\df\6ffb48299bba36fd2fc5d14dc8ae7d1caa3416aa7e96d605b7
Successfully built acvl_utils
Installing collected packages: argparse, connected-components-3d, acvl_utils
Successfully installed acvl_utils-0.2 argparse-1.4.0 connected-components-3d-3.22.0
```
</details>

## Testing with SlicerTotalSegmentator
I have also tested this in the context of [SlicerTotalSegmentator](https://github.com/lassoan/SlicerTotalSegmentator) . I have issued https://github.com/lassoan/SlicerTotalSegmentator/pull/67 to switch SlicerTotalSegmentator to also use SlicerNNUnet extension to avoid this situation again where SlicerTotalSegmentator got fixes that SlicerNNUNet did not get. I used a fresh install of Slicer 5.7.0-2024-12-31 with a cleared out system pip cache so that all downloads would be fresh.

![image](https://github.com/user-attachments/assets/aa47c1a1-ea49-491f-a6ea-929d8b51aaa1)


<details>
  <summary>SlicerTotalSegmentator python console output click here</summary>

```python
Python 3.9.10 (main, Dec 31 2024, 23:19:20) [MSC v.1939 64 bit (AMD64)] on win32
>>> 
Collecting pandas
  Downloading pandas-2.2.3-cp39-cp39-win_amd64.whl.metadata (19 kB)
Requirement already satisfied: numpy>=1.22.4 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from pandas) (1.26.4)
Requirement already satisfied: python-dateutil>=2.8.2 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from pandas) (2.9.0.post0)
Collecting pytz>=2020.1 (from pandas)
  Downloading pytz-2024.2-py2.py3-none-any.whl.metadata (22 kB)
Collecting tzdata>=2022.7 (from pandas)
  Downloading tzdata-2024.2-py2.py3-none-any.whl.metadata (1.4 kB)
Requirement already satisfied: six>=1.5 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from python-dateutil>=2.8.2->pandas) (1.16.0)
Downloading pandas-2.2.3-cp39-cp39-win_amd64.whl (11.6 MB)
   ---------------------------------------- 11.6/11.6 MB 6.5 MB/s eta 0:00:00
Downloading pytz-2024.2-py2.py3-none-any.whl (508 kB)
   ---------------------------------------- 508.0/508.0 kB 8.0 MB/s eta 0:00:00
Downloading tzdata-2024.2-py2.py3-none-any.whl (346 kB)
   ---------------------------------------- 346.6/346.6 kB 2.0 MB/s eta 0:00:00
Installing collected packages: pytz, tzdata, pandas
Successfully installed pandas-2.2.3 pytz-2024.2 tzdata-2024.2
Collecting light-the-torch>=0.5
  Downloading light_the_torch-0.8.0-py3-none-any.whl.metadata (9.3 kB)
Requirement already satisfied: pip<24.4,>=22.3 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from light-the-torch>=0.5) (24.0)
Downloading light_the_torch-0.8.0-py3-none-any.whl (14 kB)
Installing collected packages: light-the-torch
Successfully installed light-the-torch-0.8.0
Collecting torch>=2.0.0
  Downloading https://download.pytorch.org/whl/cu124/torch-2.5.1%2Bcu124-cp39-cp39-win_amd64.whl (2510.7 MB)
     ---------------------------------------- 2.5/2.5 GB 1.4 MB/s eta 0:00:00
Collecting torchvision
  Downloading https://download.pytorch.org/whl/cu124/torchvision-0.20.1%2Bcu124-cp39-cp39-win_amd64.whl (6.1 MB)
     ---------------------------------------- 6.1/6.1 MB 16.4 MB/s eta 0:00:00
Collecting filelock (from torch>=2.0.0)
  Downloading https://download.pytorch.org/whl/filelock-3.13.1-py3-none-any.whl (11 kB)
Requirement already satisfied: typing-extensions>=4.8.0 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from torch>=2.0.0) (4.12.1)
Collecting networkx (from torch>=2.0.0)
  Downloading https://download.pytorch.org/whl/networkx-3.2.1-py3-none-any.whl (1.6 MB)
     ---------------------------------------- 1.6/1.6 MB 17.6 MB/s eta 0:00:00
Collecting jinja2 (from torch>=2.0.0)
  Downloading jinja2-3.1.5-py3-none-any.whl.metadata (2.6 kB)
Collecting fsspec (from torch>=2.0.0)
  Downloading https://download.pytorch.org/whl/fsspec-2024.2.0-py3-none-any.whl (170 kB)
     ------------------------------------- 170.9/170.9 kB 10.0 MB/s eta 0:00:00
Collecting sympy==1.13.1 (from torch>=2.0.0)
  Downloading https://download.pytorch.org/whl/sympy-1.13.1-py3-none-any.whl (6.2 MB)
     ---------------------------------------- 6.2/6.2 MB 18.8 MB/s eta 0:00:00
Collecting mpmath<1.4,>=1.1.0 (from sympy==1.13.1->torch>=2.0.0)
  Downloading https://download.pytorch.org/whl/mpmath-1.3.0-py3-none-any.whl (536 kB)
     ------------------------------------- 536.2/536.2 kB 17.0 MB/s eta 0:00:00
Requirement already satisfied: numpy in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from torchvision) (1.26.4)
Requirement already satisfied: pillow!=8.3.*,>=5.3.0 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from torchvision) (10.3.0)
Collecting MarkupSafe>=2.0 (from jinja2->torch>=2.0.0)
  Downloading MarkupSafe-3.0.2-cp39-cp39-win_amd64.whl.metadata (4.1 kB)
Downloading jinja2-3.1.5-py3-none-any.whl (134 kB)
   ---------------------------------------- 134.6/134.6 kB 1.6 MB/s eta 0:00:00
Downloading MarkupSafe-3.0.2-cp39-cp39-win_amd64.whl (15 kB)
Installing collected packages: mpmath, sympy, networkx, MarkupSafe, fsspec, filelock, jinja2, torch, torchvision
Successfully installed MarkupSafe-3.0.2 filelock-3.13.1 fsspec-2024.2.0 jinja2-3.1.5 mpmath-1.3.0 networkx-3.2.1 sympy-1.13.1 torch-2.5.1+cu124 torchvision-0.20.1+cu124
Collecting nnunetv2>=2.2.1
  Downloading nnunetv2-2.5.1.tar.gz (196 kB)
     -------------------------------------- 197.0/197.0 kB 1.5 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Building wheels for collected packages: nnunetv2
  Building wheel for nnunetv2 (pyproject.toml): started
  Building wheel for nnunetv2 (pyproject.toml): finished with status 'done'
  Created wheel for nnunetv2: filename=nnunetv2-2.5.1-py3-none-any.whl size=264428 sha256=2ad70af904a73190ecb38046a84d569b352f8421d6ca8b1a94ad512667b946c7
  Stored in directory: c:\users\butlej30383\appdata\local\pip\cache\wheels\7b\85\af\51e5381b7cf9cc417ca071b9cd6e35afc59236a0ebb4462249
Successfully built nnunetv2
Installing collected packages: nnunetv2
Successfully installed nnunetv2-2.5.1
Collecting dynamic-network-architectures<0.4,>=0.3.1
  Downloading dynamic_network_architectures-0.3.1.tar.gz (20 kB)
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Building wheels for collected packages: dynamic-network-architectures
  Building wheel for dynamic-network-architectures (setup.py): started
  Building wheel for dynamic-network-architectures (setup.py): finished with status 'done'
  Created wheel for dynamic-network-architectures: filename=dynamic_network_architectures-0.3.1-py3-none-any.whl size=30056 sha256=8d7546a50ebdfbade048f7fcc67b577fd5b25971518e75e949b378afda3f6fc1
  Stored in directory: c:\users\butlej30383\appdata\local\pip\cache\wheels\ec\59\c1\e65ad8b5ac7df95651f913251875b4cc8275644e0e28e82c63
Successfully built dynamic-network-architectures
Installing collected packages: dynamic-network-architectures
Successfully installed dynamic-network-architectures-0.3.1
Collecting tqdm
  Downloading tqdm-4.67.1-py3-none-any.whl.metadata (57 kB)
     -------------------------------------- 57.7/57.7 kB 435.2 kB/s eta 0:00:00
Downloading tqdm-4.67.1-py3-none-any.whl (78 kB)
   ---------------------------------------- 78.5/78.5 kB 2.2 MB/s eta 0:00:00
Installing collected packages: tqdm
Successfully installed tqdm-4.67.1
Collecting colorama
  Downloading colorama-0.4.6-py2.py3-none-any.whl.metadata (17 kB)
Downloading colorama-0.4.6-py2.py3-none-any.whl (25 kB)
Installing collected packages: colorama
Successfully installed colorama-0.4.6
Collecting dicom2nifti
  Downloading dicom2nifti-2.5.1-py3-none-any.whl.metadata (1.3 kB)
Downloading dicom2nifti-2.5.1-py3-none-any.whl (43 kB)
   ---------------------------------------- 43.6/43.6 kB 710.8 kB/s eta 0:00:00
Installing collected packages: dicom2nifti
Successfully installed dicom2nifti-2.5.1
Collecting nibabel
  Downloading nibabel-5.3.2-py3-none-any.whl.metadata (9.1 kB)
Downloading nibabel-5.3.2-py3-none-any.whl (3.3 MB)
   ---------------------------------------- 3.3/3.3 MB 5.7 MB/s eta 0:00:00
Installing collected packages: nibabel
Successfully installed nibabel-5.3.2
Collecting importlib-resources>=5.12
  Downloading importlib_resources-6.4.5-py3-none-any.whl.metadata (4.0 kB)
Downloading importlib_resources-6.4.5-py3-none-any.whl (36 kB)
Installing collected packages: importlib-resources
Successfully installed importlib-resources-6.4.5
Collecting zipp>=3.1.0
  Downloading zipp-3.21.0-py3-none-any.whl.metadata (3.7 kB)
Downloading zipp-3.21.0-py3-none-any.whl (9.6 kB)
Installing collected packages: zipp
Successfully installed zipp-3.21.0
Collecting python-gdcm
  Downloading python_gdcm-3.0.24.1-cp39-cp39-win_amd64.whl.metadata (3.8 kB)
Downloading python_gdcm-3.0.24.1-cp39-cp39-win_amd64.whl (28.9 MB)
   ---------------------------------------- 28.9/28.9 MB 4.8 MB/s eta 0:00:00
Installing collected packages: python-gdcm
Successfully installed python-gdcm-3.0.24.1
Collecting batchgenerators>=0.25
  Downloading batchgenerators-0.25.1.tar.gz (76 kB)
     -------------------------------------- 77.0/77.0 kB 717.5 kB/s eta 0:00:00
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Building wheels for collected packages: batchgenerators
  Building wheel for batchgenerators (setup.py): started
  Building wheel for batchgenerators (setup.py): finished with status 'done'
  Created wheel for batchgenerators: filename=batchgenerators-0.25.1-py3-none-any.whl size=93102 sha256=ef464be755e76bb5c5f81ec906759fcf230d0aecd0aaa1c655e8072c0a965788
  Stored in directory: c:\users\butlej30383\appdata\local\pip\cache\wheels\97\8d\b9\3a9435d619b6a4bcd98f8cb8b324da29b6173555bb80860bdd
Successfully built batchgenerators
Installing collected packages: batchgenerators
Successfully installed batchgenerators-0.25.1
Collecting scikit-image
  Downloading scikit_image-0.24.0-cp39-cp39-win_amd64.whl.metadata (14 kB)
Downloading scikit_image-0.24.0-cp39-cp39-win_amd64.whl (12.9 MB)
   ---------------------------------------- 12.9/12.9 MB 5.3 MB/s eta 0:00:00
Installing collected packages: scikit-image
Successfully installed scikit-image-0.24.0
Collecting imageio>=2.33
  Downloading imageio-2.36.1-py3-none-any.whl.metadata (5.2 kB)
Downloading imageio-2.36.1-py3-none-any.whl (315 kB)
   ---------------------------------------- 315.4/315.4 kB 2.4 MB/s eta 0:00:00
Installing collected packages: imageio
Successfully installed imageio-2.36.1
Collecting tifffile>=2022.8.12
  Downloading tifffile-2024.8.30-py3-none-any.whl.metadata (31 kB)
Downloading tifffile-2024.8.30-py3-none-any.whl (227 kB)
   ---------------------------------------- 227.3/227.3 kB 3.5 MB/s eta 0:00:00
Installing collected packages: tifffile
Successfully installed tifffile-2024.8.30
Collecting lazy-loader>=0.4
  Downloading lazy_loader-0.4-py3-none-any.whl.metadata (7.6 kB)
Downloading lazy_loader-0.4-py3-none-any.whl (12 kB)
Installing collected packages: lazy-loader
Successfully installed lazy-loader-0.4
Collecting scikit-learn
  Downloading scikit_learn-1.6.0-cp39-cp39-win_amd64.whl.metadata (15 kB)
Downloading scikit_learn-1.6.0-cp39-cp39-win_amd64.whl (11.1 MB)
   ---------------------------------------- 11.1/11.1 MB 6.2 MB/s eta 0:00:00
Installing collected packages: scikit-learn
Successfully installed scikit-learn-1.6.0
Collecting joblib>=1.2.0
  Downloading joblib-1.4.2-py3-none-any.whl.metadata (5.4 kB)
Downloading joblib-1.4.2-py3-none-any.whl (301 kB)
   ---------------------------------------- 301.8/301.8 kB 1.6 MB/s eta 0:00:00
Installing collected packages: joblib
Successfully installed joblib-1.4.2
Collecting threadpoolctl>=3.1.0
  Downloading threadpoolctl-3.5.0-py3-none-any.whl.metadata (13 kB)
Downloading threadpoolctl-3.5.0-py3-none-any.whl (18 kB)
Installing collected packages: threadpoolctl
Successfully installed threadpoolctl-3.5.0
Collecting future
  Downloading future-1.0.0-py3-none-any.whl.metadata (4.0 kB)
Downloading future-1.0.0-py3-none-any.whl (491 kB)
   ---------------------------------------- 491.3/491.3 kB 2.8 MB/s eta 0:00:00
Installing collected packages: future
Successfully installed future-1.0.0
Collecting unittest2
  Downloading unittest2-1.1.0-py2.py3-none-any.whl.metadata (15 kB)
Downloading unittest2-1.1.0-py2.py3-none-any.whl (96 kB)
   ---------------------------------------- 96.4/96.4 kB 1.4 MB/s eta 0:00:00
Installing collected packages: unittest2
Successfully installed unittest2-1.1.0
Collecting argparse
  Downloading argparse-1.4.0-py2.py3-none-any.whl.metadata (2.8 kB)
Downloading argparse-1.4.0-py2.py3-none-any.whl (23 kB)
Installing collected packages: argparse
Successfully installed argparse-1.4.0
Collecting traceback2
  Downloading traceback2-1.4.0-py2.py3-none-any.whl.metadata (1.5 kB)
Downloading traceback2-1.4.0-py2.py3-none-any.whl (16 kB)
Installing collected packages: traceback2
Successfully installed traceback2-1.4.0
Collecting linecache2
  Downloading linecache2-1.0.0-py2.py3-none-any.whl.metadata (1000 bytes)
Downloading linecache2-1.0.0-py2.py3-none-any.whl (12 kB)
Installing collected packages: linecache2
Successfully installed linecache2-1.0.0
Collecting graphviz
  Downloading graphviz-0.20.3-py3-none-any.whl.metadata (12 kB)
Downloading graphviz-0.20.3-py3-none-any.whl (47 kB)
   ---------------------------------------- 47.1/47.1 kB 784.8 kB/s eta 0:00:00
Installing collected packages: graphviz
Successfully installed graphviz-0.20.3
Collecting matplotlib
  Downloading matplotlib-3.9.4-cp39-cp39-win_amd64.whl.metadata (11 kB)
Downloading matplotlib-3.9.4-cp39-cp39-win_amd64.whl (7.8 MB)
   ---------------------------------------- 7.8/7.8 MB 4.5 MB/s eta 0:00:00
Installing collected packages: matplotlib
Successfully installed matplotlib-3.9.4
Collecting contourpy>=1.0.1
  Downloading contourpy-1.3.0-cp39-cp39-win_amd64.whl.metadata (5.4 kB)
Downloading contourpy-1.3.0-cp39-cp39-win_amd64.whl (211 kB)
   ---------------------------------------- 211.8/211.8 kB 1.1 MB/s eta 0:00:00
Installing collected packages: contourpy
Successfully installed contourpy-1.3.0
Collecting cycler>=0.10
  Downloading cycler-0.12.1-py3-none-any.whl.metadata (3.8 kB)
Downloading cycler-0.12.1-py3-none-any.whl (8.3 kB)
Installing collected packages: cycler
Successfully installed cycler-0.12.1
Collecting fonttools>=4.22.0
  Downloading fonttools-4.55.3-cp39-cp39-win_amd64.whl.metadata (168 kB)
     -------------------------------------- 168.5/168.5 kB 2.6 MB/s eta 0:00:00
Downloading fonttools-4.55.3-cp39-cp39-win_amd64.whl (2.2 MB)
   ---------------------------------------- 2.2/2.2 MB 4.7 MB/s eta 0:00:00
Installing collected packages: fonttools
Successfully installed fonttools-4.55.3
Collecting kiwisolver>=1.3.1
  Downloading kiwisolver-1.4.7-cp39-cp39-win_amd64.whl.metadata (6.4 kB)
Downloading kiwisolver-1.4.7-cp39-cp39-win_amd64.whl (55 kB)
   ---------------------------------------- 55.8/55.8 kB 723.9 kB/s eta 0:00:00
Installing collected packages: kiwisolver
Successfully installed kiwisolver-1.4.7
Collecting seaborn
  Downloading seaborn-0.13.2-py3-none-any.whl.metadata (5.4 kB)
Downloading seaborn-0.13.2-py3-none-any.whl (294 kB)
   ---------------------------------------- 294.9/294.9 kB 2.0 MB/s eta 0:00:00
Installing collected packages: seaborn
Successfully installed seaborn-0.13.2
Collecting imagecodecs
  Downloading imagecodecs-2024.12.30-1-cp39-cp39-win_amd64.whl.metadata (19 kB)
Downloading imagecodecs-2024.12.30-1-cp39-cp39-win_amd64.whl (28.9 MB)
   ---------------------------------------- 28.9/28.9 MB 5.5 MB/s eta 0:00:00
Installing collected packages: imagecodecs
Successfully installed imagecodecs-2024.12.30
Collecting yacs
  Downloading yacs-0.1.8-py3-none-any.whl.metadata (639 bytes)
Downloading yacs-0.1.8-py3-none-any.whl (14 kB)
Installing collected packages: yacs
Successfully installed yacs-0.1.8
Collecting PyYAML
  Downloading PyYAML-6.0.2-cp39-cp39-win_amd64.whl.metadata (2.1 kB)
Downloading PyYAML-6.0.2-cp39-cp39-win_amd64.whl (162 kB)
   ---------------------------------------- 162.3/162.3 kB 1.6 MB/s eta 0:00:00
Installing collected packages: PyYAML
Successfully installed PyYAML-6.0.2
Collecting batchgeneratorsv2>=0.2
  Downloading batchgeneratorsv2-0.2.1.tar.gz (34 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Building wheels for collected packages: batchgeneratorsv2
  Building wheel for batchgeneratorsv2 (pyproject.toml): started
  Building wheel for batchgeneratorsv2 (pyproject.toml): finished with status 'done'
  Created wheel for batchgeneratorsv2: filename=batchgeneratorsv2-0.2.1-py3-none-any.whl size=45216 sha256=27475a00e9a4228188ad2a80b706c400c9d2bb41ba896ea4983e7fe54ad6b285
  Stored in directory: c:\users\butlej30383\appdata\local\pip\cache\wheels\8c\29\14\3fdf4a97638724355746fb142b55db6868f1c0f1698af26ebd
Successfully built batchgeneratorsv2
Installing collected packages: batchgeneratorsv2
Successfully installed batchgeneratorsv2-0.2.1
Collecting fft-conv-pytorch
  Downloading fft_conv_pytorch-1.2.0-py3-none-any.whl.metadata (2.8 kB)
Downloading fft_conv_pytorch-1.2.0-py3-none-any.whl (6.8 kB)
Installing collected packages: fft-conv-pytorch
Successfully installed fft-conv-pytorch-1.2.0
Collecting einops
  Downloading einops-0.8.0-py3-none-any.whl.metadata (12 kB)
Downloading einops-0.8.0-py3-none-any.whl (43 kB)
   ---------------------------------------- 43.2/43.2 kB 701.8 kB/s eta 0:00:00
Installing collected packages: einops
Successfully installed einops-0.8.0
Collecting acvl_utils==0.2
  Downloading acvl_utils-0.2.tar.gz (18 kB)
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Requirement already satisfied: numpy in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from acvl_utils==0.2) (1.26.4)
Requirement already satisfied: batchgenerators in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from acvl_utils==0.2) (0.25.1)
Requirement already satisfied: torch in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from acvl_utils==0.2) (2.5.1+cu124)
Requirement already satisfied: SimpleITK in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from acvl_utils==0.2) (2.4.0rc2.dev213)
Requirement already satisfied: scikit-image in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from acvl_utils==0.2) (0.24.0)
Collecting connected-components-3d (from acvl_utils==0.2)
  Downloading connected_components_3d-3.22.0-cp39-cp39-win_amd64.whl.metadata (32 kB)
Requirement already satisfied: pillow>=7.1.2 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from batchgenerators->acvl_utils==0.2) (10.3.0)
Requirement already satisfied: scipy in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from batchgenerators->acvl_utils==0.2) (1.13.1)
Requirement already satisfied: scikit-learn in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from batchgenerators->acvl_utils==0.2) (1.6.0)
Requirement already satisfied: future in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from batchgenerators->acvl_utils==0.2) (1.0.0)
Requirement already satisfied: pandas in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from batchgenerators->acvl_utils==0.2) (2.2.3)
Requirement already satisfied: unittest2 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from batchgenerators->acvl_utils==0.2) (1.1.0)
Requirement already satisfied: threadpoolctl in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from batchgenerators->acvl_utils==0.2) (3.5.0)
Requirement already satisfied: networkx>=2.8 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from scikit-image->acvl_utils==0.2) (3.2.1)
Requirement already satisfied: imageio>=2.33 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from scikit-image->acvl_utils==0.2) (2.36.1)
Requirement already satisfied: tifffile>=2022.8.12 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from scikit-image->acvl_utils==0.2) (2024.8.30)
Requirement already satisfied: packaging>=21 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from scikit-image->acvl_utils==0.2) (24.0)
Requirement already satisfied: lazy-loader>=0.4 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from scikit-image->acvl_utils==0.2) (0.4)
Requirement already satisfied: filelock in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from torch->acvl_utils==0.2) (3.13.1)
Requirement already satisfied: typing-extensions>=4.8.0 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from torch->acvl_utils==0.2) (4.12.1)
Requirement already satisfied: jinja2 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from torch->acvl_utils==0.2) (3.1.5)
Requirement already satisfied: fsspec in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from torch->acvl_utils==0.2) (2024.2.0)
Requirement already satisfied: sympy==1.13.1 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from torch->acvl_utils==0.2) (1.13.1)
Requirement already satisfied: mpmath<1.4,>=1.1.0 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from sympy==1.13.1->torch->acvl_utils==0.2) (1.3.0)
Requirement already satisfied: MarkupSafe>=2.0 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from jinja2->torch->acvl_utils==0.2) (3.0.2)
Requirement already satisfied: python-dateutil>=2.8.2 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from pandas->batchgenerators->acvl_utils==0.2) (2.9.0.post0)
Requirement already satisfied: pytz>=2020.1 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from pandas->batchgenerators->acvl_utils==0.2) (2024.2)
Requirement already satisfied: tzdata>=2022.7 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from pandas->batchgenerators->acvl_utils==0.2) (2024.2)
Requirement already satisfied: joblib>=1.2.0 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from scikit-learn->batchgenerators->acvl_utils==0.2) (1.4.2)
Collecting argparse (from unittest2->batchgenerators->acvl_utils==0.2)
  Using cached argparse-1.4.0-py2.py3-none-any.whl.metadata (2.8 kB)
Requirement already satisfied: six>=1.4 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from unittest2->batchgenerators->acvl_utils==0.2) (1.16.0)
Requirement already satisfied: traceback2 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from unittest2->batchgenerators->acvl_utils==0.2) (1.4.0)
Requirement already satisfied: linecache2 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from traceback2->unittest2->batchgenerators->acvl_utils==0.2) (1.0.0)
Downloading connected_components_3d-3.22.0-cp39-cp39-win_amd64.whl (545 kB)
   ---------------------------------------- 545.5/545.5 kB 4.9 MB/s eta 0:00:00
Using cached argparse-1.4.0-py2.py3-none-any.whl (23 kB)
Building wheels for collected packages: acvl_utils
  Building wheel for acvl_utils (setup.py): started
  Building wheel for acvl_utils (setup.py): finished with status 'done'
  Created wheel for acvl_utils: filename=acvl_utils-0.2-py3-none-any.whl size=22450 sha256=565173fa58e9c290bc076063b9a571d6180ba7ba9b545a89accc15ca6d731700
  Stored in directory: c:\users\butlej30383\appdata\local\pip\cache\wheels\db\79\df\6ffb48299bba36fd2fc5d14dc8ae7d1caa3416aa7e96d605b7
Successfully built acvl_utils
Installing collected packages: argparse, connected-components-3d, acvl_utils
Successfully installed acvl_utils-0.2 argparse-1.4.0 connected-components-3d-3.22.0
Collecting https://github.com/wasserth/TotalSegmentator/archive/7274faac4673298d17b63a5a8335006f02e6d426.zip
  Downloading https://github.com/wasserth/TotalSegmentator/archive/7274faac4673298d17b63a5a8335006f02e6d426.zip
     / 8.3 MB 5.0 MB/s 0:00:01
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Building wheels for collected packages: TotalSegmentator
  Building wheel for TotalSegmentator (pyproject.toml): started
  Building wheel for TotalSegmentator (pyproject.toml): finished with status 'done'
  Created wheel for TotalSegmentator: filename=TotalSegmentator-2.4.0-py3-none-any.whl size=348319 sha256=d4b53e53e781f64db7518e79038ab07cd4dc3720572b612ce20068d3811b0560
  Stored in directory: C:\Users\butlej30383\AppData\Local\Temp\pip-ephem-wheel-cache-shop__u8\wheels\d8\41\ce\20b3efb2dd6cebf94e551445b85bf8412c77d640fe7bd41cbb
Successfully built TotalSegmentator
Installing collected packages: TotalSegmentator
Successfully installed TotalSegmentator-2.4.0
Requirement already satisfied: numpy<2 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (1.26.4)
Requirement already satisfied: nibabel>=2.3.0 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (5.3.2)
Requirement already satisfied: importlib-resources>=5.12 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from nibabel>=2.3.0) (6.4.5)
Requirement already satisfied: numpy>=1.22 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from nibabel>=2.3.0) (1.26.4)
Requirement already satisfied: packaging>=20 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from nibabel>=2.3.0) (24.0)
Requirement already satisfied: typing-extensions>=4.6 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from nibabel>=2.3.0) (4.12.1)
Requirement already satisfied: zipp>=3.1.0 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from importlib-resources>=5.12->nibabel>=2.3.0) (3.21.0)
Requirement already satisfied: tqdm>=4.45.0 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (4.67.1)
Requirement already satisfied: colorama in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from tqdm>=4.45.0) (0.4.6)
Collecting p_tqdm
  Downloading p_tqdm-1.4.2.tar.gz (6.0 kB)
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Requirement already satisfied: tqdm>=4.45.0 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from p_tqdm) (4.67.1)
Collecting pathos>=0.2.5 (from p_tqdm)
  Downloading pathos-0.3.3-py3-none-any.whl.metadata (11 kB)
Requirement already satisfied: six>=1.13.0 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from p_tqdm) (1.16.0)
Collecting ppft>=1.7.6.9 (from pathos>=0.2.5->p_tqdm)
  Downloading ppft-1.7.6.9-py3-none-any.whl.metadata (12 kB)
Collecting dill>=0.3.9 (from pathos>=0.2.5->p_tqdm)
  Downloading dill-0.3.9-py3-none-any.whl.metadata (10 kB)
Collecting pox>=0.3.5 (from pathos>=0.2.5->p_tqdm)
  Downloading pox-0.3.5-py3-none-any.whl.metadata (8.0 kB)
Collecting multiprocess>=0.70.17 (from pathos>=0.2.5->p_tqdm)
  Downloading multiprocess-0.70.17-py39-none-any.whl.metadata (7.2 kB)
Requirement already satisfied: colorama in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from tqdm>=4.45.0->p_tqdm) (0.4.6)
Downloading pathos-0.3.3-py3-none-any.whl (82 kB)
   ---------------------------------------- 82.1/82.1 kB 2.3 MB/s eta 0:00:00
Downloading dill-0.3.9-py3-none-any.whl (119 kB)
   ---------------------------------------- 119.4/119.4 kB 7.3 MB/s eta 0:00:00
Downloading multiprocess-0.70.17-py39-none-any.whl (133 kB)
   ---------------------------------------- 133.4/133.4 kB 4.0 MB/s eta 0:00:00
Downloading pox-0.3.5-py3-none-any.whl (29 kB)
Downloading ppft-1.7.6.9-py3-none-any.whl (56 kB)
   ---------------------------------------- 56.8/56.8 kB 2.9 MB/s eta 0:00:00
Building wheels for collected packages: p_tqdm
  Building wheel for p_tqdm (setup.py): started
  Building wheel for p_tqdm (setup.py): finished with status 'done'
  Created wheel for p_tqdm: filename=p_tqdm-1.4.2-py3-none-any.whl size=5426 sha256=9d00808bc6b757918c57dd5b8b837d71eda38aff24337ede80b337a47e6fe134
  Stored in directory: c:\users\butlej30383\appdata\local\pip\cache\wheels\c1\d1\fa\5b7790c4da9b335ab699bbb968084fc6faaf3187f3c16a908e
Successfully built p_tqdm
Installing collected packages: ppft, pox, dill, multiprocess, pathos, p_tqdm
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
totalsegmentator 2.4.0 requires pyarrow, which is not installed.
totalsegmentator 2.4.0 requires xvfbwrapper, which is not installed.
Successfully installed dill-0.3.9 multiprocess-0.70.17 p_tqdm-1.4.2 pathos-0.3.3 pox-0.3.5 ppft-1.7.6.9
Collecting xvfbwrapper
  Downloading xvfbwrapper-0.2.9.tar.gz (5.6 kB)
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Building wheels for collected packages: xvfbwrapper
  Building wheel for xvfbwrapper (setup.py): started
  Building wheel for xvfbwrapper (setup.py): finished with status 'done'
  Created wheel for xvfbwrapper: filename=xvfbwrapper-0.2.9-py3-none-any.whl size=5028 sha256=a4f52962b0dafc97ad74551b86c9da42d39ba63e9dea12a4a4c47261bbc25a88
  Stored in directory: c:\users\butlej30383\appdata\local\pip\cache\wheels\aa\09\0e\c0fa4c721cfb0a003121597a24181add912b7488054d2311ad
Successfully built xvfbwrapper
Installing collected packages: xvfbwrapper
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
totalsegmentator 2.4.0 requires pyarrow, which is not installed.
Successfully installed xvfbwrapper-0.2.9
Requirement already satisfied: dicom2nifti in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (2.5.1)
Requirement already satisfied: nibabel in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from dicom2nifti) (5.3.2)
Requirement already satisfied: numpy in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from dicom2nifti) (1.26.4)
Requirement already satisfied: scipy in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from dicom2nifti) (1.13.1)
Requirement already satisfied: pydicom>=2.2.0 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from dicom2nifti) (2.4.4)
Requirement already satisfied: python-gdcm in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from dicom2nifti) (3.0.24.1)
Requirement already satisfied: importlib-resources>=5.12 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from nibabel->dicom2nifti) (6.4.5)
Requirement already satisfied: packaging>=20 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from nibabel->dicom2nifti) (24.0)
Requirement already satisfied: typing-extensions>=4.6 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from nibabel->dicom2nifti) (4.12.1)
Requirement already satisfied: zipp>=3.1.0 in c:\users\butlej30383\appdata\local\slicer.org\slicer 5.7.0-2024-12-31\lib\python\lib\site-packages (from importlib-resources>=5.12->nibabel->dicom2nifti) (3.21.0)
Collecting pyarrow
  Downloading pyarrow-18.1.0-cp39-cp39-win_amd64.whl.metadata (3.4 kB)
Downloading pyarrow-18.1.0-cp39-cp39-win_amd64.whl (25.3 MB)
   ---------------------------------------- 25.3/25.3 MB 6.0 MB/s eta 0:00:00
Installing collected packages: pyarrow
Successfully installed pyarrow-18.1.0
```
</details>

cc: @lassoan @Thibault-Pelletier 